### PR TITLE
Database migration with 'dotnet ef migrations add' works.

### DIFF
--- a/GenerateMigration.cmd
+++ b/GenerateMigration.cmd
@@ -1,0 +1,35 @@
+@echo off
+
+set RUN_COMMAND=dotnet ef migrations add
+
+if '%1' == '' goto USAGE
+if '%2' == '' goto USAGE
+if not '%3' == '' goto USAGE
+
+set PROJECT_DIR=%1
+set MIGRATION_NAME=%2
+
+pushd %PROJECT_DIR%
+
+%RUN_COMMAND% %MIGRATION_NAME% --configuration MIGRATION
+if ERRORLEVEL 1 echo Failed to create migration
+
+popd
+
+exit /b %ERRORLEVEL%
+
+
+:USAGE
+echo.
+echo This batch-file helps to generate database migration source files with the '%RUN_COMMAND%' command.
+echo.
+echo USAGE:
+
+echo %~n0 ^<PROJECT_DIR^> ^<MIGRATION_NAME^>
+echo.
+echo ^<PROJECT_DIR^>    - the project diretcory when the migration is required.
+echo ^<MIGRATION_NAME^> - the name of the migration
+echo                    (equals to the 'name' parameter of the '%RUN_COMMAND%' command).
+
+exit /b 1
+

--- a/OnlineSales.sln
+++ b/OnlineSales.sln
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		stylecop.json = stylecop.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnlineSales", "src\OnlineSales\OnlineSales.csproj", "{D340D06E-35D2-4C38-809A-E7EBDA9BE1B7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OnlineSales", "src\OnlineSales\OnlineSales.csproj", "{D340D06E-35D2-4C38-809A-E7EBDA9BE1B7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OnlineSales.Tests", "tests\OnlineSales.Tests\OnlineSales.Tests.csproj", "{D8B4F2A5-5C3E-464C-B1B7-FF4C716D09FC}"
 EndProject
@@ -46,36 +46,48 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OnlineSales.Plugin.AzureAD"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OnlineSales.Plugin.Email", "plugins\OnlineSales.Plugin.Email\OnlineSales.Plugin.Email.csproj", "{6A24D6C8-268E-43EE-8990-D0CDD431D6DE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnlineSales.Plugin.Vsto", "plugins\OnlineSales.Plugin.Vsto\OnlineSales.Plugin.Vsto.csproj", "{1DA75BFA-CEFD-4B3D-87D6-76E17FD20282}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OnlineSales.Plugin.Vsto", "plugins\OnlineSales.Plugin.Vsto\OnlineSales.Plugin.Vsto.csproj", "{1DA75BFA-CEFD-4B3D-87D6-76E17FD20282}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Migration|Any CPU = Migration|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D340D06E-35D2-4C38-809A-E7EBDA9BE1B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D340D06E-35D2-4C38-809A-E7EBDA9BE1B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D340D06E-35D2-4C38-809A-E7EBDA9BE1B7}.Migration|Any CPU.ActiveCfg = Migration|Any CPU
+		{D340D06E-35D2-4C38-809A-E7EBDA9BE1B7}.Migration|Any CPU.Build.0 = Migration|Any CPU
 		{D340D06E-35D2-4C38-809A-E7EBDA9BE1B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D340D06E-35D2-4C38-809A-E7EBDA9BE1B7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D8B4F2A5-5C3E-464C-B1B7-FF4C716D09FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D8B4F2A5-5C3E-464C-B1B7-FF4C716D09FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8B4F2A5-5C3E-464C-B1B7-FF4C716D09FC}.Migration|Any CPU.ActiveCfg = Migration|Any CPU
 		{D8B4F2A5-5C3E-464C-B1B7-FF4C716D09FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8B4F2A5-5C3E-464C-B1B7-FF4C716D09FC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{98630F81-A093-47B1-9A12-9B73A52BA2B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{98630F81-A093-47B1-9A12-9B73A52BA2B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98630F81-A093-47B1-9A12-9B73A52BA2B4}.Migration|Any CPU.ActiveCfg = Migration|Any CPU
+		{98630F81-A093-47B1-9A12-9B73A52BA2B4}.Migration|Any CPU.Build.0 = Migration|Any CPU
 		{98630F81-A093-47B1-9A12-9B73A52BA2B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98630F81-A093-47B1-9A12-9B73A52BA2B4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{72C2D973-92A7-4520-95E9-E53B48A064DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{72C2D973-92A7-4520-95E9-E53B48A064DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72C2D973-92A7-4520-95E9-E53B48A064DC}.Migration|Any CPU.ActiveCfg = Migration|Any CPU
+		{72C2D973-92A7-4520-95E9-E53B48A064DC}.Migration|Any CPU.Build.0 = Migration|Any CPU
 		{72C2D973-92A7-4520-95E9-E53B48A064DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{72C2D973-92A7-4520-95E9-E53B48A064DC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A24D6C8-268E-43EE-8990-D0CDD431D6DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A24D6C8-268E-43EE-8990-D0CDD431D6DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A24D6C8-268E-43EE-8990-D0CDD431D6DE}.Migration|Any CPU.ActiveCfg = Migration|Any CPU
+		{6A24D6C8-268E-43EE-8990-D0CDD431D6DE}.Migration|Any CPU.Build.0 = Migration|Any CPU
 		{6A24D6C8-268E-43EE-8990-D0CDD431D6DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A24D6C8-268E-43EE-8990-D0CDD431D6DE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1DA75BFA-CEFD-4B3D-87D6-76E17FD20282}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1DA75BFA-CEFD-4B3D-87D6-76E17FD20282}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DA75BFA-CEFD-4B3D-87D6-76E17FD20282}.Migration|Any CPU.ActiveCfg = Migration|Any CPU
+		{1DA75BFA-CEFD-4B3D-87D6-76E17FD20282}.Migration|Any CPU.Build.0 = Migration|Any CPU
 		{1DA75BFA-CEFD-4B3D-87D6-76E17FD20282}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DA75BFA-CEFD-4B3D-87D6-76E17FD20282}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/plugins/OnlineSales.Plugin.AzureAD/OnlineSales.Plugin.AzureAD.csproj
+++ b/plugins/OnlineSales.Plugin.AzureAD/OnlineSales.Plugin.AzureAD.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <ReleaseVersion>1.0.14-pre</ReleaseVersion>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <Configurations>Debug;Release;Migration</Configurations>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +20,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'!='Migration'">
     <ProjectReference Include="..\..\src\OnlineSales\OnlineSales.csproj">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
@@ -29,5 +30,14 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.25.10" />
     <!-- Insert additional references above this line -->
+  </ItemGroup>
+
+  <!--This ItemGroup is required to support migration generating with the "dotnet ef migrations add" command-->
+  <ItemGroup Condition="'$(Configuration)'=='Migration'">
+    <ProjectReference Include="..\..\src\OnlineSales\OnlineSales.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/plugins/OnlineSales.Plugin.Email/OnlineSales.Plugin.Email.csproj
+++ b/plugins/OnlineSales.Plugin.Email/OnlineSales.Plugin.Email.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <ReleaseVersion>1.0.14-pre</ReleaseVersion>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <Configurations>Debug;Release;Migration</Configurations>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +20,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'!='Migration'">
     <ProjectReference Include="..\..\src\OnlineSales\OnlineSales.csproj">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
@@ -28,5 +29,14 @@
   <ItemGroup>
     <PackageReference Include="MailKit" Version="3.4.3" />
     <!-- Insert additional references above this line -->
+  </ItemGroup>
+
+  <!--This ItemGroup is required to support migration generating with the "dotnet ef migrations add" command-->
+  <ItemGroup Condition="'$(Configuration)'=='Migration'">
+    <ProjectReference Include="..\..\src\OnlineSales\OnlineSales.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/plugins/OnlineSales.Plugin.Sms/OnlineSales.Plugin.Sms.csproj
+++ b/plugins/OnlineSales.Plugin.Sms/OnlineSales.Plugin.Sms.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <ReleaseVersion>1.0.14-pre</ReleaseVersion>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <Configurations>Debug;Release;Migration</Configurations>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,13 +15,12 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <ItemGroup>
     <Content Include="pluginsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'!='Migration'">
     <ProjectReference Include="..\..\src\OnlineSales\OnlineSales.csproj">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
@@ -30,5 +30,14 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.100.29" />
     <PackageReference Include="libphonenumber-csharp" Version="8.13.1" />
     <!-- Insert additional references above this line -->
+  </ItemGroup>
+
+  <!--This ItemGroup is required to support migration generating with the "dotnet ef migrations add" command-->
+  <ItemGroup Condition="'$(Configuration)'=='Migration'">
+    <ProjectReference Include="..\..\src\OnlineSales\OnlineSales.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/plugins/OnlineSales.Plugin.Vsto/Data/VstoDbContext.cs
+++ b/plugins/OnlineSales.Plugin.Vsto/Data/VstoDbContext.cs
@@ -11,11 +11,12 @@ namespace OnlineSales.Plugin.Vsto.Data;
 
 public class VstoDbContext : PluginDbContextBase
 {
-    // Default constructor is required for the 'dotnet ef migrations' command.
+#if MIGRATION
     public VstoDbContext()
         : base()
     {
     }
+#endif
 
     public VstoDbContext(DbContextOptions<ApiDbContext> options, IConfiguration configuration, IHttpContextHelper httpContextHelper)
         : base(options, configuration, httpContextHelper)

--- a/plugins/OnlineSales.Plugin.Vsto/OnlineSales.Plugin.Vsto.csproj
+++ b/plugins/OnlineSales.Plugin.Vsto/OnlineSales.Plugin.Vsto.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <ReleaseVersion>1.0.14-pre</ReleaseVersion>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <Configurations>Debug;Release;Migration</Configurations>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +20,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'!='Migration'">
     <ProjectReference Include="..\..\src\OnlineSales\OnlineSales.csproj">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
@@ -29,13 +30,13 @@
     <Folder Include="Configuration\" />
     <Folder Include="Entities\" />
   </ItemGroup>
-  <!-- This is necessary for 'dotnet ef' but it leads to an exception in app = builder.Build();
-  Perhaps, if we exclude 'runtime' (or something else) from <IncludeAssets> below, it will resolve the issue.
-  <ItemGroup>
+
+  <!--This ItemGroup is required to support migration generating with the "dotnet ef migrations add" command-->
+  <ItemGroup Condition="'$(Configuration)'=='Migration'">
+    <ProjectReference Include="..\..\src\OnlineSales\OnlineSales.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  -->
 </Project>

--- a/src/OnlineSales/Data/PluginDbContextBase.cs
+++ b/src/OnlineSales/Data/PluginDbContextBase.cs
@@ -10,10 +10,16 @@ namespace OnlineSales.Data;
 
 public abstract class PluginDbContextBase : ApiDbContext
 {
+    // This constructor is required in the migration source files generation process only
+    // (see the 'dotnet ef migrations' command)
+#if MIGRATION
+    // NB! Do not forget to add a default construcot to your class, devived from PluginDbContextBase,
+    // under #if MIGRATION/#endif like here.
     protected PluginDbContextBase()
         : base()
     {
     }
+#endif
 
     protected PluginDbContextBase(DbContextOptions<ApiDbContext> options, IConfiguration configuration, IHttpContextHelper httpContextHelper)
         : base(options, configuration, httpContextHelper)

--- a/src/OnlineSales/OnlineSales.csproj
+++ b/src/OnlineSales/OnlineSales.csproj
@@ -27,9 +27,9 @@
     <PackageVersion>$(ReleaseVersion)</PackageVersion>
     <Version>$(ReleaseVersion)</Version>
     <IsPackable>true</IsPackable>
+    <Configurations>Debug;Release;Migration</Configurations>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <ItemGroup>
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.5.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
@@ -40,10 +40,6 @@
     <PackageReference Include="Elasticsearch.Net" Version="7.17.5" />
     <PackageReference Include="NEST" Version="7.17.5" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -69,5 +65,13 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
+  </ItemGroup>
+
+  <!--This ItemGroup is required to support migration generation with the "dotnet ef migrations add" command-->
+  <ItemGroup Condition="'$(Configuration)'=='Migration'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/tests/OnlineSales.Tests/OnlineSales.Tests.csproj
+++ b/tests/OnlineSales.Tests/OnlineSales.Tests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <ReleaseVersion>1.0.14-pre</ReleaseVersion>
+    <Configurations>Debug;Release;Migration</Configurations>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
On the one hand, the 'dotnet ef migrations add' command requires the Microsoft.EntityFrameworkCore.Design refence in assembly. On the other hand, this extra dependency affects to runtime and leads to raising an exception in WebApplication.Build().
This commit adds a new build configuration to solution which is used only by the 'dotnet ef migrations add' command, includes all necessary dependencies and doesn't affect to runtime.

As a bonus, there is a Windows batch file GenerateMigration.cmd that calls the 'dotnet ef migrations add' with correct build configuration.