### PR TITLE
null_query_empty_response

### DIFF
--- a/src/OnlineSales/Infrastructure/DBQueryProvider.cs
+++ b/src/OnlineSales/Infrastructure/DBQueryProvider.cs
@@ -214,9 +214,16 @@ namespace OnlineSales.Infrastructure
 
                 foreach (var value in parsedValues)
                 {
-                    var valueParameterExpression = Expression.Constant(value, cmd.Property.PropertyType);
-                    var eqExpression = Expression.Equal(parameter, valueParameterExpression);
-                    orExpression = Expression.Or(orExpression, eqExpression);
+                    if (value == null && !cmd.IsNullableProperty())
+                    {
+                        return Expression.Constant(false);
+                    }
+                    else
+                    {
+                        var valueParameterExpression = Expression.Constant(value, cmd.Property.PropertyType);
+                        var eqExpression = Expression.Equal(parameter, valueParameterExpression);
+                        orExpression = Expression.Or(orExpression, eqExpression);
+                    }
                 }
 
                 return orExpression;
@@ -224,18 +231,8 @@ namespace OnlineSales.Infrastructure
 
             Expression CreateNEqualExpression(QueryParseData<T>.WhereUnitData cmd, Expression parameter)
             {
-                Expression andExpression = Expression.Constant(true);
-                var stringValues = cmd.ParseStringValues();
-                var parsedValues = cmd.ParseValues(stringValues);
-
-                foreach (var value in parsedValues)
-                {
-                    var valueParameterExpression = Expression.Constant(value, cmd.Property.PropertyType);
-                    var eqExpression = Expression.NotEqual(parameter, valueParameterExpression);
-                    andExpression = Expression.And(andExpression, eqExpression);
-                }
-
-                return andExpression;
+                var expression = CreateEqualExpression(cmd, parameter);
+                return Expression.Not(expression);
             }
 
             Expression? CreateCompareExpression(QueryParseData<T>.WhereUnitData cmd, Expression parameter)

--- a/src/OnlineSales/Infrastructure/QueryParseData.cs
+++ b/src/OnlineSales/Infrastructure/QueryParseData.cs
@@ -438,7 +438,7 @@ namespace OnlineSales.Infrastructure
 
                 foreach (var sv in input)
                 {
-                    if (IsNullableProperty() && sv == "null" && GetUnderlyingPropertyType() != typeof(string))
+                    if (sv == "null" && GetUnderlyingPropertyType() != typeof(string))
                     {
                         result.Add(null);
                     }
@@ -514,6 +514,13 @@ namespace OnlineSales.Infrastructure
                 return result;
             }
 
+            public bool IsNullableProperty()
+            {
+                var context = new NullabilityInfoContext();
+                var info = context.Create(Property);
+                return info.WriteState == NullabilityState.Nullable;
+            }
+
             private static PropertyInfo ParseProperty(string? propertyName, QueryCommand cmd)
             {
                 if (propertyName == null || string.IsNullOrWhiteSpace(propertyName))
@@ -530,14 +537,7 @@ namespace OnlineSales.Infrastructure
                 }
 
                 return property;
-            }
-
-            private bool IsNullableProperty()
-            {
-                var context = new NullabilityInfoContext();
-                var info = context.Create(Property);
-                return info.WriteState == NullabilityState.Nullable;
-            }
+            }          
 
             private Type GetUnderlyingPropertyType()
             {

--- a/tests/OnlineSales.Tests/EmailGroupsTests.cs
+++ b/tests/OnlineSales.Tests/EmailGroupsTests.cs
@@ -64,6 +64,10 @@ public class EmailGroupsTests : SimpleTableTests<EmailGroup, TestEmailGroup, Ema
         result!.Count.Should().Be(5);
         result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][UpdatedAt][neq]=null");
         result!.Count.Should().Be(0);
+        result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][CreatedAt][eq]=null");
+        result!.Count.Should().Be(0);
+        result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][CreatedAt][neq]=null");
+        result!.Count.Should().Be(5);
         result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][Name][eq]=Test1|Test2");
         result!.Count.Should().Be(2);
         result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][Name][neq]=Test1|Test2");

--- a/tests/OnlineSales.Tests/OrdersTests.cs
+++ b/tests/OnlineSales.Tests/OrdersTests.cs
@@ -66,6 +66,10 @@ public class OrdersTests : TableWithFKTests<Order, TestOrder, OrderUpdateDto, IS
         result!.Count.Should().Be(5);
         result = await GetTest<List<Order>>(itemsUrl + "?filter[where][UpdatedAt][neq]=null&query=q");
         result!.Count.Should().Be(0);
+        result = await GetTest<List<Order>>(itemsUrl + "?filter[where][CreatedAt][eq]=null&query=q");
+        result!.Count.Should().Be(0);
+        result = await GetTest<List<Order>>(itemsUrl + "?filter[where][CreatedAt][neq]=null&query=q");
+        result!.Count.Should().Be(5);
         result = await GetTest<List<Order>>(itemsUrl + "?filter[where][AffiliateName][eq]=Test1 q&query=q");
         result!.Count.Should().Be(1);
         result = await GetTest<List<Order>>(itemsUrl + "?filter[where][AffiliateName][eq]=Test5 q|Test6 q&query=q");


### PR DESCRIPTION
Empty array is returned if null query (e.g. where[createdAt][eq]=null) is used for nonnullable property.