### PR TITLE
feature_where_empty_query_as_null

### DIFF
--- a/src/OnlineSales/Infrastructure/QueryParseData.cs
+++ b/src/OnlineSales/Infrastructure/QueryParseData.cs
@@ -438,7 +438,7 @@ namespace OnlineSales.Infrastructure
 
                 foreach (var sv in input)
                 {
-                    if (sv == "null" && GetUnderlyingPropertyType() != typeof(string))
+                    if ((sv == "null" || sv == string.Empty) && GetUnderlyingPropertyType() != typeof(string))
                     {
                         result.Add(null);
                     }
@@ -471,6 +471,10 @@ namespace OnlineSales.Infrastructure
                         else if (GetUnderlyingPropertyType() == typeof(string))
                         {
                             result.Add(sv);
+                            if (sv == string.Empty)
+                            {
+                                result.Add(null);
+                            }
                         }
                         else
                         {

--- a/tests/OnlineSales.Tests/EmailGroupsTests.cs
+++ b/tests/OnlineSales.Tests/EmailGroupsTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using OnlineSales.DataAnnotations;
-using OnlineSales.Interfaces;
 
 namespace OnlineSales.Tests;
 public class EmailGroupsTests : SimpleTableTests<EmailGroup, TestEmailGroup, EmailGroupUpdateDto, ISaveService<EmailGroup>>
@@ -62,12 +61,18 @@ public class EmailGroupsTests : SimpleTableTests<EmailGroup, TestEmailGroup, Ema
 
         var result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][UpdatedAt][eq]=null");
         result!.Count.Should().Be(5);
+        result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][UpdatedAt][eq]=");
+        result!.Count.Should().Be(5);
         result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][UpdatedAt][neq]=null");
+        result!.Count.Should().Be(0);
+        result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][UpdatedAt][neq]=");
         result!.Count.Should().Be(0);
         result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][CreatedAt][eq]=null");
         result!.Count.Should().Be(0);
         result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][CreatedAt][neq]=null");
         result!.Count.Should().Be(5);
+        result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][Name][eq]=");
+        result!.Count.Should().Be(0);
         result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][Name][eq]=Test1|Test2");
         result!.Count.Should().Be(2);
         result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][Name][neq]=Test1|Test2");
@@ -129,7 +134,7 @@ public class EmailGroupsTests : SimpleTableTests<EmailGroup, TestEmailGroup, Ema
         bulkEntitiesList.Add(mapper.Map<EmailGroup>(bulkList));
         App.PopulateBulkData<EmailGroup, ISaveService<EmailGroup>>(bulkEntitiesList);
 
-        var result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][CreatedAt]=", HttpStatusCode.BadRequest);
+        var result = await GetTest<List<EmailGroup>>(itemsUrl + "?filter[where][CreatedAt][gt]=", HttpStatusCode.BadRequest);
         result.Should().BeNull();
 
         var now = DateTime.UtcNow;

--- a/tests/OnlineSales.Tests/OrdersTests.cs
+++ b/tests/OnlineSales.Tests/OrdersTests.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the samples root for full license information.
 // </copyright>
 
-using OnlineSales.DataAnnotations;
 using OnlineSales.Infrastructure;
-using OnlineSales.Interfaces;
 
 namespace OnlineSales.Tests;
 
@@ -62,9 +60,17 @@ public class OrdersTests : TableWithFKTests<Order, TestOrder, OrderUpdateDto, IS
         App.PopulateBulkData<Order, ISaveService<Order>>(bulkEntitiesList);
         await SyncElasticSearch();
 
-        var result = await GetTest<List<Order>>(itemsUrl + "?filter[where][UpdatedAt][eq]=null&query=q");
+        var result = await GetTest<List<Order>>(itemsUrl + "?filter[where][ContactIp][eq]=&query=q");
+        result!.Count.Should().Be(5);
+        result = await GetTest<List<Order>>(itemsUrl + "?filter[where][ContactIp][neq]=&query=q");
+        result!.Count.Should().Be(0); 
+        result = await GetTest<List<Order>>(itemsUrl + "?filter[where][UpdatedAt][eq]=null&query=q");
         result!.Count.Should().Be(5);
         result = await GetTest<List<Order>>(itemsUrl + "?filter[where][UpdatedAt][neq]=null&query=q");
+        result!.Count.Should().Be(0);
+        result = await GetTest<List<Order>>(itemsUrl + "?filter[where][UpdatedAt][eq]=&query=q");
+        result!.Count.Should().Be(5);
+        result = await GetTest<List<Order>>(itemsUrl + "?filter[where][UpdatedAt][neq]=&query=q");
         result!.Count.Should().Be(0);
         result = await GetTest<List<Order>>(itemsUrl + "?filter[where][CreatedAt][eq]=null&query=q");
         result!.Count.Should().Be(0);
@@ -94,7 +100,7 @@ public class OrdersTests : TableWithFKTests<Order, TestOrder, OrderUpdateDto, IS
         App.PopulateBulkData<Order, ISaveService<Order>>(bulkEntitiesList);
         await SyncElasticSearch();
 
-        var result = await GetTest<List<Order>>(itemsUrl + "?filter[where][CreatedAt]=&query=q", HttpStatusCode.BadRequest);
+        var result = await GetTest<List<Order>>(itemsUrl + "?filter[where][CreatedAt][gt]=&query=q", HttpStatusCode.BadRequest);
         result.Should().BeNull();
 
         var now = DateTime.UtcNow;


### PR DESCRIPTION
Now all queries like '[where][CreatedAt][eq]=' are queries for null values. In the case of string propperties it's query for null or empty value.