### PR TITLE
Fix default language for email templates

### DIFF
--- a/src/OnlineSales/Configuration/AppSettings.cs
+++ b/src/OnlineSales/Configuration/AppSettings.cs
@@ -71,6 +71,8 @@ public class ApiSettingsConfig
     public int MaxListSize { get; set; }
 
     public string MaxImportSize { get; set; } = string.Empty;
+
+    public string Language { get; set; } = "ru-RU";
 }
 
 public class GeolocationApiConfig
@@ -122,9 +124,4 @@ public class CorsConfig
 public class EmailConfig : BaseServiceConfig
 {
     public bool UseSsl { get; set; }
-}
-
-public class DefaultLanguage
-{
-    public string Language { get; set; } = "ru-RU";
 }

--- a/src/OnlineSales/Configuration/AppSettings.cs
+++ b/src/OnlineSales/Configuration/AppSettings.cs
@@ -123,3 +123,8 @@ public class EmailConfig : BaseServiceConfig
 {
     public bool UseSsl { get; set; }
 }
+
+public class DefaultLanguage
+{
+    public string Language { get; set; } = "ru-RU";
+}

--- a/src/OnlineSales/Configuration/AppSettings.cs
+++ b/src/OnlineSales/Configuration/AppSettings.cs
@@ -72,7 +72,7 @@ public class ApiSettingsConfig
 
     public string MaxImportSize { get; set; } = string.Empty;
 
-    public string Language { get; set; } = "ru-RU";
+    public string DefaultLanguage { get; set; } = "en-US";
 }
 
 public class GeolocationApiConfig

--- a/src/OnlineSales/Exceptions/EntityNotFoundException.cs
+++ b/src/OnlineSales/Exceptions/EntityNotFoundException.cs
@@ -15,22 +15,7 @@ public class EntityNotFoundException : Exception
         EntityUid = entityUid;
     }
 
-    public EntityNotFoundException(string? message)
-        : base(message)
-    {
-    }
+    public string EntityType { get; init; }
 
-    public EntityNotFoundException(string? message, Exception? innerException)
-        : base(message, innerException)
-    {
-    }
-
-    protected EntityNotFoundException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-
-    public string EntityType { get; init; } = string.Empty;
-
-    public string EntityUid { get; init; } = string.Empty;
+    public string EntityUid { get; init; }
 }

--- a/src/OnlineSales/appsettings.json
+++ b/src/OnlineSales/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "AllowedHosts": "*",
   "MigrateOnStart": true,
-  "Plugins": [ "OnlineSales.Plugin.ReverseProxy", "OnlineSales.Plugin.EmailSync", "OnlineSales.Plugin.XLTools" ],
+  "Plugins": [ "OnlineSales.Plugin.ReverseProxy", "OnlineSales.Plugin.EmailSync" ],
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",
@@ -126,7 +126,8 @@
   },
   "ApiSettings": {
     "MaxListSize": 10,
-    "MaxImportSize": "5MB"
+    "MaxImportSize": "5MB",
+    "Language": "en-US"
   },
   "EmailVerificationApi": {
     "Url": "https://emailverification.whoisxmlapi.com/api/v2",
@@ -144,7 +145,4 @@
     "Scope": "$AZUREAD__SCOPE",
     "ClientSecret": "$AZUREAD__CLIENTSECRET"
   },
-  "DefaultLanguage": {
-    "Language": "ru-RU"
-  }
 }

--- a/src/OnlineSales/appsettings.json
+++ b/src/OnlineSales/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "AllowedHosts": "*",
   "MigrateOnStart": true,
-  "Plugins": [ "OnlineSales.Plugin.ReverseProxy", "OnlineSales.Plugin.EmailSync" ],
+  "Plugins": [ "OnlineSales.Plugin.ReverseProxy", "OnlineSales.Plugin.EmailSync", "OnlineSales.Plugin.XLTools" ],
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",
@@ -143,5 +143,8 @@
     "ClientId": "$AZUREAD__CLIENTID",
     "Scope": "$AZUREAD__SCOPE",
     "ClientSecret": "$AZUREAD__CLIENTSECRET"
+  },
+  "DefaultLanguage": {
+    "Language": "ru-RU"
   }
 }

--- a/src/OnlineSales/appsettings.json
+++ b/src/OnlineSales/appsettings.json
@@ -127,7 +127,7 @@
   "ApiSettings": {
     "MaxListSize": 10,
     "MaxImportSize": "5MB",
-    "Language": "en-US"
+    "DefaultLanguage": "en-US"
   },
   "EmailVerificationApi": {
     "Url": "https://emailverification.whoisxmlapi.com/api/v2",
@@ -144,5 +144,5 @@
     "ClientId": "$AZUREAD__CLIENTID",
     "Scope": "$AZUREAD__SCOPE",
     "ClientSecret": "$AZUREAD__CLIENTSECRET"
-  },
+  }
 }


### PR DESCRIPTION
Added section 'DefaultLanguage' into AppSettings.json with Language property with default value as 'ru-RU'.
Added method GetEmailTemplateByLanguage into EmailFromTemplateService to search template with provided or default language.