### PR TITLE
Fixed CreatedAt property value to get current UTC datetime

### DIFF
--- a/src/OnlineSales/Entities/BaseEntity.cs
+++ b/src/OnlineSales/Entities/BaseEntity.cs
@@ -20,7 +20,7 @@ public class BaseEntity : BaseCreateByEntity, IHasUpdatedAt, IHasUpdatedBy
 public class BaseCreateByEntity : BaseEntityWithId, IHasCreatedAt, IHasCreatedBy
 {
     [Required]
-    public DateTime CreatedAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     public string? CreatedByIp { get; set; }
 
@@ -30,7 +30,7 @@ public class BaseCreateByEntity : BaseEntityWithId, IHasCreatedAt, IHasCreatedBy
 public class BaseEntityWithIdAndDates : BaseEntityWithId, IHasCreatedAt, IHasUpdatedAt
 {
     [Required]
-    public DateTime CreatedAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     public DateTime? UpdatedAt { get; set; }
 }


### PR DESCRIPTION
public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

to make migrations with correct dates like 
 { 1, new DateTime(2023, 6, 1, 8, 3, 15, 627, DateTimeKind.Utc).AddTicks(6266), .... },