### PR TITLE
EsOnlyQueryProviderFactory

### DIFF
--- a/src/OnlineSales/Controllers/ActivityLogController.cs
+++ b/src/OnlineSales/Controllers/ActivityLogController.cs
@@ -21,9 +21,9 @@ namespace OnlineSales.Controllers;
 public class ActivityLogController : ControllerBase
 {    
     private readonly IMapper mapper;
-    private readonly QueryProviderFactory<ActivityLog> queryProviderFactory;
+    private readonly ESOnlyQueryProviderFactory<ActivityLog> queryProviderFactory;
 
-    public ActivityLogController(PgDbContext dbContext, IConfiguration configuration, IMapper mapper, IOptions<ApiSettingsConfig> apiSettingsConfig, EsDbContext esDbContext, QueryProviderFactory<ActivityLog> queryProviderFactory)
+    public ActivityLogController(PgDbContext dbContext, IConfiguration configuration, IMapper mapper, IOptions<ApiSettingsConfig> apiSettingsConfig, EsDbContext esDbContext, ESOnlyQueryProviderFactory<ActivityLog> queryProviderFactory)
     {        
         this.mapper = mapper;
         this.queryProviderFactory = queryProviderFactory;

--- a/src/OnlineSales/Infrastructure/ESOnlyQueryProviderFactory.cs
+++ b/src/OnlineSales/Infrastructure/ESOnlyQueryProviderFactory.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="ESOnlyQueryProviderFactory.cs" company="WavePoint Co. Ltd.">
+// Licensed under the MIT license. See LICENSE file in the samples root for full license information.
+// </copyright>
+
+using System.Web;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Nest;
+using OnlineSales.Configuration;
+using OnlineSales.Data;
+using OnlineSales.DataAnnotations;
+using OnlineSales.Entities;
+using OnlineSales.Interfaces;
+
+namespace OnlineSales.Infrastructure
+{
+    public class ESOnlyQueryProviderFactory<T> : QueryProviderFactory<T>
+        where T : BaseEntityWithId, new()
+    {
+        public ESOnlyQueryProviderFactory(PgDbContext dbContext, EsDbContext esDbContext, IOptions<ApiSettingsConfig> apiSettingsConfig, IHttpContextHelper? httpContextHelper)
+            : base(dbContext, esDbContext, apiSettingsConfig, httpContextHelper)
+        {
+        }
+
+        public override IQueryProvider<T> BuildQueryProvider(int limit = -1)
+        {
+            var queryCommands = QueryStringParser.Parse(httpContextHelper.Request.QueryString.HasValue ? HttpUtility.UrlDecode(httpContextHelper.Request.QueryString.ToString()) : string.Empty);
+
+            var queryBuilder = new QueryModelBuilder<T>(queryCommands, limit == -1 ? apiSettingsConfig.Value.MaxListSize : limit, dbContext);
+
+            var indexPrefix = dbContext.Configuration.GetSection("Elastic:IndexPrefix").Get<string>();
+            return new ESQueryProvider<T>(elasticClient, queryBuilder, indexPrefix!);
+        }
+    }
+}

--- a/src/OnlineSales/Program.cs
+++ b/src/OnlineSales/Program.cs
@@ -69,6 +69,7 @@ public class Program
         builder.Services.AddSingleton<TaskStatusService, TaskStatusService>();
         builder.Services.AddSingleton<ActivityLogService, ActivityLogService>();
         builder.Services.AddTransient(typeof(QueryProviderFactory<>), typeof(QueryProviderFactory<>));
+        builder.Services.AddTransient(typeof(ESOnlyQueryProviderFactory<>), typeof(ESOnlyQueryProviderFactory<>));
         builder.Services.AddSingleton<IEmailService, EmailService>();
         builder.Services.AddTransient<CommentableControllerExtension, CommentableControllerExtension>();
         builder.Services.AddScoped<IDealService, DealService>();


### PR DESCRIPTION
EsOnlyQueryProviderFactory is needed to fix get query for activity logs, because activity logs aren't contained in the postgres, but in elastic db only.