### PR TITLE
Fix: updated authorization configuration handling

### DIFF
--- a/src/LeadCMS/Infrastructure/IdentityHelper.cs
+++ b/src/LeadCMS/Infrastructure/IdentityHelper.cs
@@ -121,13 +121,35 @@ public static class IdentityHelper
 
     public static void ConfigureAuthorization(WebApplicationBuilder builder)
     {
+        var jwtConfig = builder.Configuration.GetSection("Jwt").Get<JwtConfig>();
+        var azureAdConfig = builder.Configuration.GetSection("AzureAd").Get<AzureADConfig>();
+
+        bool jwtEnabled = jwtConfig != null && jwtConfig.Secret != "$JWT__SECRET";
+        bool azureAdEnabled = azureAdConfig != null && azureAdConfig.TenantId != "$AZUREAD__TENANTID";
+
         builder.Services.AddAuthorization(options =>
         {
-            // Default policy that requires authenticated user from either JwtBearer or AzureAd scheme
-            options.DefaultPolicy = new AuthorizationPolicyBuilder()
-                .AddAuthenticationSchemes(JwtBearerScheme, AzureAdScheme)
-                .RequireAuthenticatedUser()
-                .Build();
+                var policyBuilder = new AuthorizationPolicyBuilder();
+
+                if (jwtEnabled)
+                {
+                policyBuilder.AddAuthenticationSchemes(JwtBearerScheme);
+                }
+
+                if (azureAdEnabled)
+                {
+                    policyBuilder.AddAuthenticationSchemes(AzureAdScheme);
+                }
+
+                // Fallback to JwtBearer if neither is configured
+                if (!jwtEnabled && !azureAdEnabled)
+                {
+                    policyBuilder.AddAuthenticationSchemes(JwtBearerScheme);
+                }
+
+                policyBuilder.RequireAuthenticatedUser();
+
+                options.DefaultPolicy = policyBuilder.Build();
         });
     }
 

--- a/src/LeadCMS/Infrastructure/IdentityHelper.cs
+++ b/src/LeadCMS/Infrastructure/IdentityHelper.cs
@@ -133,7 +133,7 @@ public static class IdentityHelper
 
                 if (jwtEnabled)
                 {
-                policyBuilder.AddAuthenticationSchemes(JwtBearerScheme);
+                    policyBuilder.AddAuthenticationSchemes(JwtBearerScheme);
                 }
 
                 if (azureAdEnabled)


### PR DESCRIPTION
**Add dynamic authorization scheme selection based on configuration**

This PR updates the authorization configuration to dynamically apply authentication schemes (JwtBearer or AzureAD) based on the application's runtime configuration.

- Reads Jwt and AzureAd settings from appsettings.json
- Selects appropriate authentication scheme(s) based on which providers are properly configured
- Falls back to JwtBearer if neither is configured
- Ensures that the default authorization policy is built accordingly

